### PR TITLE
[Refactoring] Fix default import export

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,15 +19,9 @@
   "license": "MIT",
   "main": "dist/index.js",
   "files": [
-    "dist",
-    "prettier.config.js"
+    "dist"
   ],
-  "exports": {
-    ".": {
-      "require": "./prettier.config.js",
-      "default": "./dist/index.js"
-    }
-  },
+  "exports": "./dist/index.js",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
@@ -42,7 +36,7 @@
     "update-version:minor": "./scripts/update-version.sh minor",
     "update-version:patch": "./scripts/update-version.sh patch",
     "build": "rimraf dist && tsc",
-    "format": "yarn build && prettier --write \"{src,linter,tests,scripts}/**/*.ts\"",
+    "format": "yarn build && prettier --config ./dist/index.js --write \"{src,linter,tests,scripts}/**/*.ts\"",
     "lint": "echo `TODO`",
     "lint:fix": "echo `TODO`",
     "publish-package": "npm publish --access public",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,0 @@
-/**
- * Adapter for Prettier to load the config from the compiled TypeScript output.
- */
-module.exports = require('./dist/index.js').default;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,4 +23,4 @@ const config: Config = {
   singleAttributePerLine: false,
 };
 
-export default config;
+export = config;


### PR DESCRIPTION
## Summary
- fix default export so ESM import returns the config directly
- remove root adapter prettier config
- update format script to reference compiled config