### PR TITLE
[Common] Switching npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.cursor/commands/release.md
+++ b/.cursor/commands/release.md
@@ -139,6 +139,6 @@ When the user says `continue`, `merged`, `done`, or similar:
 - If `yarn update-version:*` fails (dirty tree, push rejected, etc.), show the error and STOP; do not invent a workaround that skips the script.
 - If a promote PR already exists, link it instead of opening a duplicate.
 - If tag `vX.X.X` already exists on a different commit, STOP and ask the user how to proceed.
-- If `project-publish.yml` fails (e.g. version already published, missing `NPM_TOKEN`), STOP with the run URL and error summary.
+- If `project-publish.yml` fails (e.g. version already published, Trusted Publisher / OIDC misconfigured), STOP with the run URL and error summary.
 
 This command will be available in chat with /release <patch|minor|major>

--- a/.github/workflows/project-publish.yml
+++ b/.github/workflows/project-publish.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -21,6 +25,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          npm install -g npm@latest
           npm install -g corepack@0.31.0
           corepack enable
           yarn install
@@ -54,5 +59,3 @@ jobs:
       - name: Publish package
         if: steps.versions.outputs.local_version != steps.versions.outputs.published_version
         run: yarn publish-package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/DEV-README.md
+++ b/DEV-README.md
@@ -61,30 +61,31 @@ Fixes errors found by ESLint in TypeScript files.
 Generates comprehensive documentation using TypeDoc.
 
 ## 📦 How to set up automatic publishing to npm
-To enable automatic publishing of the package when changes are pushed to the `main` branch, follow these steps:
-### 1. 🔐 Generate an Automation Token on npm
-1. Open your NPM package on https://npmjs.com -> Access Tokens
-2. Click **"Generate New Token" -> "Classic Token"**, then choose **Type** - `Automation`
-3. Copy the generated token (you won’t be able to see it again!).
+Publishing uses [Trusted Publishing](https://docs.npmjs.com/trusted-publishers/) (OIDC). No npm token is stored in GitHub Secrets.
 
-📘 See [npm’s official docs] for more info.
+### 1. 🔐 Configure Trusted Publisher on npm
+1. Open the package on https://npmjs.com → **Package Settings** → **Trusted Publisher**.
+2. Choose **GitHub Actions** and fill in:
+   - **Organization or user:** `a1exevs`
+   - **Repository:** `prettier-config`
+   - **Workflow filename:** `project-publish.yml`
+   - **Environment name:** `npm`
+   - **Allowed actions:** `npm publish` only (do not enable `npm stage publish` unless you switch the workflow to staged publishing)
+3. Save.
 
-### 2. 🔑 Add the Token to GitHub Secrets
-1. Open your GitHub repository.
-2. Go to **Settings → Secrets and variables → Actions**.
-3. Click **"New repository secret"**.
-4. Name it: `NPM_TOKEN`
-5. Paste the token value.
+📘 See [npm Trusted Publishers docs](https://docs.npmjs.com/trusted-publishers/).
 
-📘 See [GitHub’s guide on encrypted secrets] for details.
+### 2. 🔑 Create the GitHub Actions environment
+1. Open the GitHub repository → **Settings → Environments**.
+2. Create an environment named `npm`.
+3. Under **Deployment branches and tags**, allow only the `main` branch.
+
+The publish job in `.github/workflows/project-publish.yml` must use the same name (`environment: npm`) and include `permissions: id-token: write`.
 
 ### 3. ✅ That’s it!
-The GitHub Actions workflow will now use `NPM_TOKEN` to publish the package when version changes are pushed to `main`.
+When a version bump is pushed to `main`, the workflow authenticates to npm via OIDC and runs `yarn publish-package`. No `NPM_TOKEN` secret is required — you can remove it if it still exists.
 > ⚠️ Make sure to bump the version in `package.json` before pushing — otherwise, the workflow will fail due to version conflict.
 ---
-
-[npm’s official docs]: https://docs.npmjs.com/creating-and-viewing-access-tokens
-[GitHub’s guide on encrypted secrets]: https://docs.github.com/en/actions/security-guides/encrypted-secrets
 
 
 ## Release steps


### PR DESCRIPTION
Replacing long-lived NPM_TOKEN auth with GitHub Actions OIDC and the npm environment. Updating the publish workflow and docs so releases no longer depend on stored registry secrets.