### PR TITLE
[Common] RELEASE-NOTES.md update v1.0.1

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,18 @@
+# Release v1.0.1
+## What's Changed
+* [Common] Pin dependencies by @renovate in https://github.com/a1exevs/prettier-config/pull/38
+* [Common] Update non-major by @renovate in https://github.com/a1exevs/prettier-config/pull/36
+* [Common] CURSOR rules, node version update, scripts upgrade by @a1exevs in https://github.com/a1exevs/prettier-config/pull/39
+* [Common] Bumping dependencies to latest compatible versions by @a1exevs in https://github.com/a1exevs/prettier-config/pull/40
+* [Common] Switching npm publish to Trusted Publishing (OIDC) by @a1exevs in https://github.com/a1exevs/prettier-config/pull/41
+* [Bugfix] Adapting version bump script for single-package repo by @a1exevs in https://github.com/a1exevs/prettier-config/pull/42
+* [Common] Version increase v1.0.1 by @a1exevs in https://github.com/a1exevs/prettier-config/pull/43
+
+## New Contributors
+* @renovate made their first contribution in https://github.com/a1exevs/prettier-config/pull/38
+
+**Full Changelog**: https://github.com/a1exevs/prettier-config/compare/v1.0.0...v1.0.1
+
 # Release v1.0.0
 ## What's Changed
 * [Common] RELEASE-NOTES.md update v0.14.0 by @a1exevs in https://github.com/a1exevs/prettier-config/pull/27


### PR DESCRIPTION
Adding GitHub Release notes for v1.0.1 to RELEASE-NOTES.md.